### PR TITLE
docs: correct example script header

### DIFF
--- a/examples/read_all.py
+++ b/examples/read_all.py
@@ -1,4 +1,4 @@
-# examples/print_all_measurements.py
+# examples/read_all.py
 # -*- coding: utf-8 -*-
 """
 Continuously print all measurements from the SEN0500/SEN0501 sensor


### PR DESCRIPTION
## Summary
- fix example header comment to reference read_all.py

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2bcac0c48321b18c9636b93ff56f