### PR TITLE
fix: validate input range in map_linear

### DIFF
--- a/dfrobot_environmental_sensor/core.py
+++ b/dfrobot_environmental_sensor/core.py
@@ -83,6 +83,9 @@ def map_linear(x: float, in_min: float, in_max: float, out_min: float, out_max: 
     ValueError
         If ``in_min == in_max``.
     """
+    if in_min == in_max:
+        raise ValueError("in_min and in_max must be different")
+
     return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
 
 


### PR DESCRIPTION
## Summary
- validate input range in map_linear to prevent division by zero

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ce9e9f08321abbc5af30c247b57