### PR TITLE
Add CI tests with mocked sensor transport

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install . --no-deps
+      - name: Run tests
+        run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Test helpers for simulating SEN050X hardware.
+
+The ``EnvironmentalSensor`` class accepts any object implementing the
+``Transport`` protocol.  ``FakeTransport`` provides a minimal in-memory
+implementation returning preset register values.  Tests can therefore
+exercise sensor logic without requiring real hardware or the ``smbus3`` or
+``modbus-tk`` dependencies.
+"""
+from dataclasses import dataclass
+from typing import Dict
+
+from dfrobot_environmental_sensor.core import EnvironmentalSensor
+from dfrobot_environmental_sensor.constants import (
+    EXPECTED_DEVICE_ID,
+    REG_DEVICE_ID,
+    REG_HUMIDITY,
+    REG_ILLUMINANCE,
+    REG_PRESSURE,
+    REG_TEMPERATURE,
+    REG_UV_IRRADIANCE,
+)
+from dfrobot_environmental_sensor.transports import Transport
+
+
+@dataclass
+class FakeTransport(Transport):
+    """Simple transport that serves register values from a dictionary."""
+
+    registers: Dict[int, int]
+
+    def read_block(self, reg: int, length: int) -> bytes:  # pragma: no cover - trivial
+        value = self.registers.get(reg, 0)
+        return value.to_bytes(length, "big")
+
+
+def build_sensor() -> EnvironmentalSensor:
+    """Construct an :class:`EnvironmentalSensor` backed by ``FakeTransport``."""
+    # Raw register values chosen to produce human-friendly measurements
+    registers = {
+        REG_DEVICE_ID: EXPECTED_DEVICE_ID,
+        REG_TEMPERATURE: 26189,   # ≈25 °C
+        REG_HUMIDITY: 36010,      # ≈55 %RH
+        REG_UV_IRRADIANCE: 800,   # ≈10.17 mW/cm²
+        REG_ILLUMINANCE: 512,     # ≈533.32 lux
+        REG_PRESSURE: 1013,       # ≈1013 hPa
+    }
+    return EnvironmentalSensor(FakeTransport(registers))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,31 @@
+import pytest
+
+from dfrobot_environmental_sensor.core import (
+    _bytes_to_u16_big_endian,
+    clamp_value,
+    convert_celsius_to_fahrenheit,
+    map_linear,
+)
+
+
+def test_convert_celsius_to_fahrenheit() -> None:
+    assert convert_celsius_to_fahrenheit(0.0) == 32.0
+    assert convert_celsius_to_fahrenheit(100.0) == 212.0
+
+
+def test_clamp_value() -> None:
+    assert clamp_value(5, 0, 10) == 5
+    assert clamp_value(-1, 0, 10) == 0
+    assert clamp_value(15, 0, 10) == 10
+
+
+def test_map_linear() -> None:
+    assert map_linear(5, 0, 10, 0, 100) == 50
+    with pytest.raises(ValueError):
+        map_linear(1, 0, 0, 0, 1)
+
+
+def test_bytes_to_u16_big_endian() -> None:
+    assert _bytes_to_u16_big_endian(b"\x12\x34") == 0x1234
+    with pytest.raises(ValueError):
+        _bytes_to_u16_big_endian(b"\x00")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,39 @@
+import pytest
+
+from dfrobot_environmental_sensor.constants import Units
+from tests.conftest import build_sensor
+
+
+@pytest.fixture
+def sensor():
+    return build_sensor()
+
+
+def test_is_present(sensor) -> None:
+    assert sensor.is_present()
+
+
+def test_read_temperature(sensor) -> None:
+    assert sensor.read_temperature(Units.C) == pytest.approx(25.0, abs=0.01)
+    assert sensor.read_temperature(Units.F) == pytest.approx(77.0, abs=0.01)
+
+
+def test_read_humidity(sensor) -> None:
+    assert sensor.read_humidity() == pytest.approx(55.0, abs=0.01)
+
+
+def test_read_uv_irradiance(sensor) -> None:
+    assert sensor.read_uv_irradiance() == pytest.approx(10.17, abs=0.01)
+
+
+def test_read_illuminance(sensor) -> None:
+    assert sensor.read_illuminance() == pytest.approx(533.32, abs=0.01)
+
+
+def test_read_pressure(sensor) -> None:
+    assert sensor.read_pressure() == pytest.approx(1013.0, abs=0.01)
+    assert sensor.read_pressure(Units.KPA) == pytest.approx(101.3, abs=0.01)
+
+
+def test_estimate_altitude(sensor) -> None:
+    assert sensor.estimate_altitude() == pytest.approx(2.08, abs=0.01)


### PR DESCRIPTION
## Summary
- run unit tests in CI across supported Python versions
- use a FakeTransport in tests to simulate SEN050X hardware
- cover core helper functions and sensor reading methods

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab2e0f810c8321baa36ef0c1e7a515