### PR TITLE
docs: add callout highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [2.0.0] - 2025-08-20
 
+> [!WARNING]
+> Version 2.0.0 removes Arduino and Python 2.x support; projects relying on these should remain on earlier releases.
+
 ### ✨ Added
 
 * Python 3.8+ support using `smbus3`

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ This sensor integrates **temperature 🌡️, humidity 💧, UV index ☀️, li
 
 It supports both **Gravity** and **Breakout** interfaces and communicates over **I²C** or **UART**.
 
-👉 This is a **Python 3.8+ only** fork of the original DFRobot Arduino library, adapted for Raspberry Pi.
+> [!IMPORTANT]
+> This fork supports Python 3.8+ only; earlier versions or Arduino libraries are not supported.
 
 ---
 
 ## 📦 Installation
 
-Simply install with `pip`
-
-```bash
-pip install dfrobot-environmental-sensor
-```
+> [!TIP]
+> Use a virtual environment to avoid dependency conflicts and run:
+>
+> ```bash
+> pip install dfrobot-environmental-sensor
+> ```
 
 ## 🚀 Pythonic API usage
 
@@ -35,6 +37,9 @@ At the top level you’ll find:
 `UVSensor` → supported UV sensor variants
 
 ### 🐍 Minimal example
+
+> [!CAUTION]
+> Ensure the I²C bus is enabled and the sensor’s address matches your hardware; some boards may use a different bus or address than `0x22`.
 
 ```python
 from dfrobot_environmental_sensor import EnvironmentalSensor, Units, UVSensor
@@ -54,6 +59,9 @@ if sensor.is_present():
 else:
     print("❌ Sensor not detected.")
 ```
+
+> [!NOTE]
+> If the sensor isn’t detected, double-check wiring, power, and address configuration.
 
 ## 🛠️ Methods
 
@@ -97,6 +105,9 @@ def estimate_altitude(self, sea_level_hpa: float = 1013.25) -> float:
 The full changelog is available in [CHANGELOG.md](./CHANGELOG.md).
 
 ### Latest Release
+
+> [!WARNING]
+> Version 2.0.0 removes Arduino and Python 2.x support; projects relying on these should remain on earlier releases.
 
 - **[2.0.0 – 2025-08-20]** 💥 Python-only fork
   - ✅ Python 3.8+ support with `smbus3`


### PR DESCRIPTION
## Summary
- emphasize Python 3.8-only requirement
- add installation, I2C, and troubleshooting tips
- flag dropped Arduino/Python2 support in changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab521615948321a5882a94842af3df