### PR TITLE
Refactor magic numbers into constants

### DIFF
--- a/dfrobot_environmental_sensor/constants.py
+++ b/dfrobot_environmental_sensor/constants.py
@@ -47,6 +47,81 @@ RAW_SCALE_FACTOR: int = 1023
 OVERSAMPLING_FACTOR: int = 64
 """Default oversampling factor used for temperature and humidity conversions."""
 
+# === Conversion factors ===
+
+CELSIUS_TO_FAHRENHEIT_SCALE: float = 1.8
+"""Multiplicative factor for Celsius→Fahrenheit conversion."""
+
+CELSIUS_TO_FAHRENHEIT_OFFSET: float = 32.0
+"""Additive offset for Celsius→Fahrenheit conversion."""
+
+UV_10BIT_MASK: int = 0x03FF
+"""Bit mask for extracting the 10-bit UV ADC value."""
+
+ADC_REFERENCE_VOLTAGE: float = 3.0
+"""Reference voltage for ADC conversions (volts)."""
+
+# LTR390UV conversion parameters
+LTR390_OUTPUT_MIN_V: float = 0.99
+"""Minimum valid output voltage for LTR390UV sensor (volts)."""
+
+LTR390_OUTPUT_MAX_V: float = 2.99
+"""Maximum valid output voltage for LTR390UV sensor (volts)."""
+
+LTR390_IRRADIANCE_MIN: float = 0.0
+"""Minimum UV irradiance for LTR390UV conversion (mW/cm²)."""
+
+LTR390_IRRADIANCE_MAX: float = 15.0
+"""Maximum UV irradiance for LTR390UV conversion (mW/cm²)."""
+
+# S12DS conversion parameters
+S12DS_NANOAMP_SCALE: float = 1e12
+"""Scale to convert volts to nanoamperes for S12DS sensor."""
+
+S12DS_LOAD_RESISTANCE_OHMS: int = 4_303_300
+"""Load resistance in the S12DS circuit (ohms)."""
+
+S12DS_NA_PER_MW_CM2: float = 113.0
+"""Nanoamperes corresponding to 1 mW/cm² for S12DS."""
+
+# Illuminance polynomial coefficients
+ILLUMINANCE_COEFF_A: float = 1.0023
+"""Coefficient A for vendor polynomial of lux conversion."""
+
+ILLUMINANCE_COEFF_B: float = 8.1488e-5
+"""Coefficient B for vendor polynomial of lux conversion."""
+
+ILLUMINANCE_COEFF_C: float = -9.3924e-9
+"""Coefficient C for vendor polynomial of lux conversion."""
+
+ILLUMINANCE_COEFF_D: float = 6.0135e-13
+"""Coefficient D for vendor polynomial of lux conversion."""
+
+PRESSURE_TO_KPA_DIVISOR: float = 10.0
+"""Divisor to convert pressure from hPa to kPa."""
+
+ALTITUDE_SCALING_FACTOR: float = 44330.0
+"""Scaling factor for barometric altitude estimation (meters)."""
+
+ALTITUDE_EXPONENT: float = 0.1903
+"""Exponent used in barometric altitude estimation."""
+
+PERCENTAGE_SCALE: float = 100.0
+"""Scale factor to convert fractional values to percentages."""
+
+# UART defaults
+UART_DATA_BITS: int = 8
+"""UART frame data bits."""
+
+UART_PARITY: str = "N"
+"""UART parity mode ("N" = none)."""
+
+UART_STOP_BITS: int = 1
+"""UART stop bits."""
+
+UART_TIMEOUT_S: float = 1.0
+"""Default UART timeout in seconds."""
+
 
 class UVSensor(Enum):
     """Enumerates supported UV sensor variants.

--- a/dfrobot_environmental_sensor/core.py
+++ b/dfrobot_environmental_sensor/core.py
@@ -53,10 +53,7 @@ def convert_celsius_to_fahrenheit(temperature_c: float) -> float:
     float
         Equivalent temperature in degrees Fahrenheit.
     """
-    return (
-        temperature_c * CELSIUS_TO_FAHRENHEIT_SCALE
-        + CELSIUS_TO_FAHRENHEIT_OFFSET
-    )
+    return temperature_c * CELSIUS_TO_FAHRENHEIT_SCALE + CELSIUS_TO_FAHRENHEIT_OFFSET
 
 
 def clamp_value(x: float, lower: float, upper: float) -> float:
@@ -79,9 +76,7 @@ def clamp_value(x: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, x))
 
 
-def map_linear(
-    x: float, in_min: float, in_max: float, out_min: float, out_max: float
-) -> float:
+def map_linear(x: float, in_min: float, in_max: float, out_min: float, out_max: float) -> float:
     """Map a value linearly from one range to another.
 
     Parameters
@@ -204,9 +199,7 @@ class EnvironmentalSensor:
         Which UV sensor variant is mounted. Defaults to ``UVSensor.LTR390UV``.
     """
 
-    def __init__(
-        self, transport: Transport, uv_sensor: UVSensor = UVSensor.LTR390UV
-    ) -> None:
+    def __init__(self, transport: Transport, uv_sensor: UVSensor = UVSensor.LTR390UV) -> None:
         self._transport = transport
         self.uv_sensor = uv_sensor
 
@@ -286,9 +279,7 @@ class EnvironmentalSensor:
         try:
             word_bytes = self._transport.read_block(reg_address, 2)
         except Exception as e:
-            raise IOError(
-                f"Failed to read 2 bytes at register 0x{reg_address:02X}"
-            ) from e
+            raise IOError(f"Failed to read 2 bytes at register 0x{reg_address:02X}") from e
         return _bytes_to_u16_big_endian(word_bytes)
 
     # ---- API ----
@@ -340,9 +331,7 @@ class EnvironmentalSensor:
             Relative humidity in percent (%RH), rounded to 2 decimals.
         """
         raw = self._read_u16(REG_HUMIDITY)
-        relative_humidity = (
-            raw / RAW_SCALE_FACTOR * PERCENTAGE_SCALE / OVERSAMPLING_FACTOR
-        )
+        relative_humidity = raw / RAW_SCALE_FACTOR * PERCENTAGE_SCALE / OVERSAMPLING_FACTOR
         return round(relative_humidity, 2)
 
     def read_uv_irradiance(self) -> float:
@@ -372,10 +361,7 @@ class EnvironmentalSensor:
         lux = raw * (
             ILLUMINANCE_COEFF_A
             + raw
-            * (
-                ILLUMINANCE_COEFF_B
-                + raw * (ILLUMINANCE_COEFF_C + raw * ILLUMINANCE_COEFF_D)
-            )
+            * (ILLUMINANCE_COEFF_B + raw * (ILLUMINANCE_COEFF_C + raw * ILLUMINANCE_COEFF_D))
         )
         return round(lux, 2)
 

--- a/dfrobot_environmental_sensor/core.py
+++ b/dfrobot_environmental_sensor/core.py
@@ -76,7 +76,9 @@ def clamp_value(x: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, x))
 
 
-def map_linear(x: float, in_min: float, in_max: float, out_min: float, out_max: float) -> float:
+def map_linear(
+    x: float, in_min: float, in_max: float, out_min: float, out_max: float
+) -> float:
     """Map a value linearly from one range to another.
 
     Parameters
@@ -199,7 +201,9 @@ class EnvironmentalSensor:
         Which UV sensor variant is mounted. Defaults to ``UVSensor.LTR390UV``.
     """
 
-    def __init__(self, transport: Transport, uv_sensor: UVSensor = UVSensor.LTR390UV) -> None:
+    def __init__(
+        self, transport: Transport, uv_sensor: UVSensor = UVSensor.LTR390UV
+    ) -> None:
         self._transport = transport
         self.uv_sensor = uv_sensor
 
@@ -279,7 +283,9 @@ class EnvironmentalSensor:
         try:
             word_bytes = self._transport.read_block(reg_address, 2)
         except Exception as e:
-            raise IOError(f"Failed to read 2 bytes at register 0x{reg_address:02X}") from e
+            raise IOError(
+                f"Failed to read 2 bytes at register 0x{reg_address:02X}"
+            ) from e
         return _bytes_to_u16_big_endian(word_bytes)
 
     # ---- API ----
@@ -331,7 +337,9 @@ class EnvironmentalSensor:
             Relative humidity in percent (%RH), rounded to 2 decimals.
         """
         raw = self._read_u16(REG_HUMIDITY)
-        relative_humidity = raw / RAW_SCALE_FACTOR * PERCENTAGE_SCALE / OVERSAMPLING_FACTOR
+        relative_humidity = (
+            raw / RAW_SCALE_FACTOR * PERCENTAGE_SCALE / OVERSAMPLING_FACTOR
+        )
         return round(relative_humidity, 2)
 
     def read_uv_irradiance(self) -> float:
@@ -361,7 +369,10 @@ class EnvironmentalSensor:
         lux = raw * (
             ILLUMINANCE_COEFF_A
             + raw
-            * (ILLUMINANCE_COEFF_B + raw * (ILLUMINANCE_COEFF_C + raw * ILLUMINANCE_COEFF_D))
+            * (
+                ILLUMINANCE_COEFF_B
+                + raw * (ILLUMINANCE_COEFF_C + raw * ILLUMINANCE_COEFF_D)
+            )
         )
         return round(lux, 2)
 

--- a/dfrobot_environmental_sensor/transports.py
+++ b/dfrobot_environmental_sensor/transports.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 from typing import Protocol
 
+from .constants import (
+    UART_DATA_BITS,
+    UART_PARITY,
+    UART_STOP_BITS,
+    UART_TIMEOUT_S,
+)
+
 
 class Transport(Protocol):
     """Abstract communication transport for SEN050X sensors.
@@ -121,10 +128,14 @@ class UARTTransport:
         self._addr = addr
         self._master = modbus_rtu.RtuMaster(
             serial.Serial(
-                port=port, baudrate=baudrate, bytesize=8, parity="N", stopbits=1
+                port=port,
+                baudrate=baudrate,
+                bytesize=UART_DATA_BITS,
+                parity=UART_PARITY,
+                stopbits=UART_STOP_BITS,
             )
         )
-        self._master.set_timeout(1.0)
+        self._master.set_timeout(UART_TIMEOUT_S)
 
     def read_block(self, reg: int, length: int) -> bytes:
         """Read a block of data from the device over Modbus RTU.

--- a/dfrobot_environmental_sensor/transports.py
+++ b/dfrobot_environmental_sensor/transports.py
@@ -90,7 +90,9 @@ class I2CTransport:
             data = self._bus.read_i2c_block_data(self._addr, reg, length)
             return bytes(data)
         except Exception as e:
-            raise IOError(f"I2C read failed (reg=0x{reg:02X}, len={length}): {e}") from e
+            raise IOError(
+                f"I2C read failed (reg=0x{reg:02X}, len={length}): {e}"
+            ) from e
 
 
 class UARTTransport:

--- a/dfrobot_environmental_sensor/transports.py
+++ b/dfrobot_environmental_sensor/transports.py
@@ -90,9 +90,7 @@ class I2CTransport:
             data = self._bus.read_i2c_block_data(self._addr, reg, length)
             return bytes(data)
         except Exception as e:
-            raise IOError(
-                f"I2C read failed (reg=0x{reg:02X}, len={length}): {e}"
-            ) from e
+            raise IOError(f"I2C read failed (reg=0x{reg:02X}, len={length}): {e}") from e
 
 
 class UARTTransport:


### PR DESCRIPTION
## Summary
- move conversion factors, sensor calibration data, and UART defaults into constants module
- replace in-line magic numbers in core calculations and transports with named constants

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab59d0c44c8321b337423a53324245